### PR TITLE
Connection exceptions

### DIFF
--- a/YandexGeocoder/ServiceProvider/DirectServiceProvider.cs
+++ b/YandexGeocoder/ServiceProvider/DirectServiceProvider.cs
@@ -93,9 +93,9 @@ namespace YandexGeocoder.ServiceProvider
                 }
 
                 cToken.ThrowIfCancellationRequested();
-                var jsonObject = await _getResponseJObject(address).ConfigureAwait(false);
                 try
                 {
+                    var jsonObject = await _getResponseJObject(address).ConfigureAwait(false);
                     var rawPoints = _parseJObjectCommon(jsonObject);
                     if (_failureStrategy == FailureStrategy.ThrowException && rawPoints.Count() == 0)
                     {

--- a/YandexGeocoder/ServiceProvider/DirectServiceProvider.cs
+++ b/YandexGeocoder/ServiceProvider/DirectServiceProvider.cs
@@ -65,8 +65,15 @@ namespace YandexGeocoder.ServiceProvider
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public async Task<bool> CheckConnection()
         {
-            var resp = await _client.GetAsync(BaseUrl).ConfigureAwait(false);
-            return resp.StatusCode == HttpStatusCode.OK;
+            try
+            {
+                var resp = await _client.GetAsync(BaseUrl).ConfigureAwait(false);
+                return resp.StatusCode == HttpStatusCode.OK;
+            }
+            catch //For example, exception on transport level
+            {
+                return false;
+            }
         }
 
         public async Task<IEnumerable<GeoPoint>> GetPoints(string address, CancellationToken cToken)


### PR DESCRIPTION
Исправление ошибок возникающих при разрыве соединения.

Пример сервера принимающего запрос на localhost:79 и сразу разрывающего соединения:
```Python3
#!/usr/bin/env python3

import socket

with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as serversocket:
    serversocket.bind(('localhost', 79))
    serversocket.listen(5)

    while True:
        (clientsocket, address) = serversocket.accept()
        with clientsocket:
            print('Connected by', address)
            while True:
                clientsocket.close()
                break
```
